### PR TITLE
Add more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# ddd
+Google Deepdream Dockerfile
+
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
 # ddd
-Google Deepdream Dockerfile
+Google Deepdream Dockerfile, forked from https://registry.hub.docker.com/u/mjibson/deepdream/ 
 
+## Installation
+- clone this repo
+- install docker
+- Build the image. `cd` in the just cloned repository folder and `docker build -t edap/ddd .`
+- create a folder where to store the output images, `mkdir ~/dreams`
 
+## Example
+Supposing that you are in your home direcotry
+  ```bash
+  docker run --rm -v `pwd`/dreams:/images edap/ddd 'https://www.google.com/logos/2013/zamboni-1005006-hp.jpg' 'inception_3b/5x5_reduce' 15 8 1.9
+  ```
+
+## Parameters
+- `'https://www.google.com/logos/2013/zamboni-1005006-hp.jpg'` Mandatory, an Url that points to a jpg
+- `'inception_3b/5x5_reduce'` Optional, default is `inception_4c/output`
+- `15` Optional, number of iteration, default is `10`
+- `8` Optional, number of octave, default is `4`
+- `1.9` Optional, number of octave_scale, default is `1.4`
+
+In the Ipython [notebook](https://github.com/google/deepdream/blob/master/dream.ipynb) you can find more details about the parameters 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Google Deepdream Dockerfile, forked from https://registry.hub.docker.com/u/mjibs
 ## Installation
 - clone this repo
 - install docker
-- Build the image. `cd` in the just cloned repository folder and `docker build -t edap/ddd .`
+- build the image. `cd` in the just cloned repository folder and `docker build -t edap/ddd .`
 - create a folder where to store the output images, `mkdir ~/dreams`
 
 ## Example
-Supposing that you are in your home direcotry
+Supposing that you are in your home directory
   ```bash
   docker run --rm -v `pwd`/dreams:/images edap/ddd 'https://www.google.com/logos/2013/zamboni-1005006-hp.jpg' 'inception_3b/5x5_reduce' 15 8 1.9
   ```
@@ -20,4 +20,4 @@ Supposing that you are in your home direcotry
 - `8` Optional, number of octave, default is `4`
 - `1.9` Optional, number of octave_scale, default is `1.4`
 
-In the Ipython [notebook](https://github.com/google/deepdream/blob/master/dream.ipynb) you can find more details about the parameters 
+In the [Ipython notebook](https://github.com/google/deepdream/blob/master/dream.ipynb) you can find more details about the parameters 

--- a/deepdreams.py
+++ b/deepdreams.py
@@ -60,6 +60,10 @@ def make_step(net, step_size=1.5, end='inception_4c/output', jitter=32, clip=Tru
 		src.data[:] = np.clip(src.data, -bias, 255-bias)
 
 def deepdream(net, base_img, end, iter_n=10, octave_n=4, octave_scale=1.4, clip=True, **step_params):
+        # print "received option"
+	# print ("iter_n" + str(iter_n))
+	# print ("ocatve_n" + str(octave_n))
+	# print ("octave_scale" + str(octave_scale))
 	# prepare base images for all octaves
 	octaves = [preprocess(net, base_img)]
 	for i in xrange(octave_n-1):
@@ -101,7 +105,17 @@ if len(sys.argv) >= 2:
 
 iter_n = 10
 if len(sys.argv) >= 3:
-	iteration = sys.argv[2]
+	iter_n = sys.argv[2]
+        iter_n = int(iter_n)
 
+octave_n = 4
+if len(sys.argv) >= 4:
+	octave_n = sys.argv[3]
+        octave_n = int(octave_n)
 
-_=deepdream(net, img, end, iter_n)
+octave_scale = 1.4
+if len(sys.argv) >= 5:
+	octave_scale = sys.argv[4]
+        octave_scale = float(octave_scale)
+
+_=deepdream(net, img, end, iter_n, octave_n, octave_scale)

--- a/deepdreams.py
+++ b/deepdreams.py
@@ -60,11 +60,7 @@ def make_step(net, step_size=1.5, end='inception_4c/output', jitter=32, clip=Tru
 		src.data[:] = np.clip(src.data, -bias, 255-bias)
 
 def deepdream(net, base_img, end, iter_n=10, octave_n=4, octave_scale=1.4, clip=True, **step_params):
-        # print "received option"
-	# print ("iter_n" + str(iter_n))
-	# print ("ocatve_n" + str(octave_n))
-	# print ("octave_scale" + str(octave_scale))
-	# prepare base images for all octaves
+        # prepare base images for all octaves
 	octaves = [preprocess(net, base_img)]
 	for i in xrange(octave_n-1):
 		octaves.append(nd.zoom(octaves[-1], (1, 1.0/octave_scale,1.0/octave_scale), order=1))

--- a/deepdreams.py
+++ b/deepdreams.py
@@ -99,4 +99,9 @@ end = 'inception_4c/output'
 if len(sys.argv) >= 2:
 	end = sys.argv[1]
 
-_=deepdream(net, img, end)
+iter_n = 10
+if len(sys.argv) >= 3:
+	iteration = sys.argv[2]
+
+
+_=deepdream(net, img, end, iter_n)

--- a/start.sh
+++ b/start.sh
@@ -13,4 +13,4 @@ fi
 
 curl $1 > /ddd/img.jpg
 
-ipython /ddd/deepdreams.py $2
+ipython /ddd/deepdreams.py $2 $3

--- a/start.sh
+++ b/start.sh
@@ -13,4 +13,4 @@ fi
 
 curl $1 > /ddd/img.jpg
 
-ipython /ddd/deepdreams.py $2 $3
+ipython /ddd/deepdreams.py $2 $3 $4 $5


### PR DESCRIPTION
Hey, many thanks for the Docker file. Installing caffe was taking too long.
I've added the options: `iter_n`, `octave_n` and `octave_scale`, so that they can be passed to the python script.